### PR TITLE
fix(minimax-xlsx): YAML frontmatter parsing error preventing skill registration

### DIFF
--- a/skills/minimax-xlsx/SKILL.md
+++ b/skills/minimax-xlsx/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: minimax-xlsx
-description: Open, create, read, analyze, edit, or validate Excel/spreadsheet files (.xlsx, .xlsm, .csv, .tsv). Use when the user asks to create, build, modify, analyze, read, validate, or format any Excel spreadsheet, financial model, pivot table, or tabular data file. Covers: creating new xlsx from scratch, reading and analyzing existing files, editing existing xlsx with zero format loss, formula recalculation and validation, and applying professional financial formatting standards. Triggers on 'spreadsheet', 'Excel', '.xlsx', '.csv', 'pivot table', 'financial model', 'formula', or any request to produce tabular data in Excel format.
+description: "Open, create, read, analyze, edit, or validate Excel/spreadsheet files (.xlsx, .xlsm, .csv, .tsv). Use when the user asks to create, build, modify, analyze, read, validate, or format any Excel spreadsheet, financial model, pivot table, or tabular data file. Covers: creating new xlsx from scratch, reading and analyzing existing files, editing existing xlsx with zero format loss, formula recalculation and validation, and applying professional financial formatting standards. Triggers on 'spreadsheet', 'Excel', '.xlsx', '.csv', 'pivot table', 'financial model', 'formula', or any request to produce tabular data in Excel format."
 license: MIT
 metadata:
   version: "1.0"


### PR DESCRIPTION
The description field in minimax-xlsx/SKILL.md YAML frontmatter contained unescaped colons (:), which caused a YAML parsing error (mapping values are not allowed in this context at line 2 column 278). This prevented npx skills add from registering the skill.

Fix: Wrap the description value in double quotes so colons and special characters are treated as literal strings rather than YAML syntax.

## Before
```
◇  Found 8 skills
│
◆  Select skills to install (space to toggle)
│  ◻ android-native-dev (Android native application development and UI design guid...)
│  ◻ frontend-dev
│  ◻ fullstack-dev
│  ◻ gif-sticker-maker
│  ◻ ios-application-dev
│  ◻ minimax-pdf
│  ◻ pptx-generator
│  ◻ shader-dev
└
```
## After
```
◇  Found 9 skills
│
◆  Select skills to install (space to toggle)
│  ◻ android-native-dev (Android native application development and UI design guid...)
│  ◻ frontend-dev
│  ◻ fullstack-dev
│  ◻ gif-sticker-maker
│  ◻ ios-application-dev
│  ◻ minimax-pdf
│  ◻ minimax-xlsx
│  ◻ pptx-generator
│  ◻ shader-dev
└
```