### PR TITLE
Fix description formatting in SKILL.md

### DIFF
--- a/skills/minimax-xlsx/SKILL.md
+++ b/skills/minimax-xlsx/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: minimax-xlsx
-description: Open, create, read, analyze, edit, or validate Excel/spreadsheet files (.xlsx, .xlsm, .csv, .tsv). Use when the user asks to create, build, modify, analyze, read, validate, or format any Excel spreadsheet, financial model, pivot table, or tabular data file. Covers: creating new xlsx from scratch, reading and analyzing existing files, editing existing xlsx with zero format loss, formula recalculation and validation, and applying professional financial formatting standards. Triggers on 'spreadsheet', 'Excel', '.xlsx', '.csv', 'pivot table', 'financial model', 'formula', or any request to produce tabular data in Excel format.
+description: "Open, create, read, analyze, edit, or validate Excel/spreadsheet files (.xlsx, .xlsm, .csv, .tsv). Use when the user asks to create, build, modify, analyze, read, validate, or format any Excel spreadsheet, financial model, pivot table, or tabular data file. Covers: creating new xlsx from scratch, reading and analyzing existing files, editing existing xlsx with zero format loss, formula recalculation and validation, and applying professional financial formatting standards. Triggers on 'spreadsheet', 'Excel', '.xlsx', '.csv', 'pivot table', 'financial model', 'formula', or any request to produce tabular data in Excel format."
 license: MIT
 metadata:
   version: "1.0"


### PR DESCRIPTION

<img width="1277" height="74" alt="image" src="https://github.com/user-attachments/assets/2897a442-926a-4780-90bb-b81c382fb236" />


fix(skills): quote minimax-xlsx description to resolve YAML parsing error