### PR TITLE
Fix invalid YAML in minimax-multimodal-toolkit skill

### DIFF
--- a/skills/minimax-multimodal-toolkit/SKILL.md
+++ b/skills/minimax-multimodal-toolkit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: minimax-multimodal-toolkit
-description: MiniMax multimodal model skill — use MiniMax  Multi-Modal models for speech, music, video, and image. Create voice, music, video, and images with MiniMax AI: TTS (text-to-speech, voice cloning, voice design, multi-segment), music (songs, instrumentals), video (text-to-video, image-to-video, start-end frame, subject reference, templates, long-form multi-scene), image (text-to-image, image-to-image with character reference), and media processing (convert, concat, trim, extract). Use when the user mentions MiniMax, multimodal generation, or wants speech/music/video/image AI, MiniMax APIs, or FFmpeg workflows alongside MiniMax outputs.
+description: "MiniMax multimodal model skill — use MiniMax Multi-Modal models for speech, music, video, and image. Create voice, music, video, and images with MiniMax AI: TTS (text-to-speech, voice cloning, voice design, multi-segment), music (songs, instrumentals), video (text-to-video, image-to-video, start-end frame, subject reference, templates, long-form multi-scene), image (text-to-image, image-to-image with character reference), and media processing (convert, concat, trim, extract). Use when the user mentions MiniMax, multimodal generation, or wants speech/music/video/image AI, MiniMax APIs, or FFmpeg workflows alongside MiniMax outputs."
 ---
 
 # MiniMax Multi-Modal Toolkit


### PR DESCRIPTION
## Summary

This fixes invalid YAML frontmatter in `skills/minimax-multimodal-toolkit/SKILL.md`.

The `description` field was written as an unquoted plain scalar and included the substring `MiniMax AI: TTS`. Because it contains `: `, YAML parsers interpret it as a mapping separator and fail with `mapping values are not allowed in this context`.

As a result, the skill loader skips this skill entirely.

## Fix

Wrap the `description` value in quotes so the frontmatter is valid YAML.

## Repro

Attempting to load the skill before this change produces an error similar to:

`invalid YAML: mapping values are not allowed in this context`

## Impact

After this change, the skill frontmatter parses correctly and the skill can be loaded normally.