### PR TITLE
fix(install): use minimax-{skill_name} prefix for identifiable and safe uninstall

### DIFF
--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -12,7 +12,10 @@
 git clone https://github.com/MiniMax-AI/skills.git ~/.minimax-skills
 
 mkdir -p ~/.config/opencode/skills
-ln -s ~/.minimax-skills/skills/* ~/.config/opencode/skills/
+for skill in ~/.minimax-skills/skills/*/; do
+    skill_name=$(basename "$skill")
+    ln -s "$skill" ~/.config/opencode/skills/minimax-"$skill_name"
+done
 ```
 
 ### Windows (PowerShell)
@@ -22,7 +25,7 @@ git clone https://github.com/MiniMax-AI/skills.git "$env:USERPROFILE\.minimax-sk
 
 New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.config\opencode\skills"
 Get-ChildItem "$env:USERPROFILE\.minimax-skills\skills" -Directory | ForEach-Object {
-    New-Item -ItemType SymbolicLink -Path "$env:USERPROFILE\.config\opencode\skills\$($_.Name)" -Target $_.FullName
+    New-Item -ItemType SymbolicLink -Path "$env:USERPROFILE\.config\opencode\skills\minimax-$($_.Name)" -Target $_.FullName
 }
 ```
 
@@ -58,14 +61,14 @@ Symlinks will automatically point to the updated content — no need to re-link.
 ### macOS / Linux
 
 ```bash
-rm -rf ~/.config/opencode/skills
+rm -f ~/.config/opencode/skills/minimax-*
 rm -rf ~/.minimax-skills
 ```
 
 ### Windows (PowerShell)
 
 ```powershell
-Remove-Item -Recurse -Force "$env:USERPROFILE\.config\opencode\skills"
+Get-ChildItem "$env:USERPROFILE\.config\opencode\skills\minimax-*" | Remove-Item -Force
 Remove-Item -Recurse -Force "$env:USERPROFILE\.minimax-skills"
 ```
 

--- a/.opencode/INSTALL_zh.md
+++ b/.opencode/INSTALL_zh.md
@@ -1,0 +1,85 @@
+# 安装 MiniMax Skills for OpenCode
+
+## 前置要求
+
+- 已安装 [OpenCode.ai](https://opencode.ai)
+
+## 安装
+
+### macOS / Linux
+
+```bash
+git clone https://github.com/MiniMax-AI/skills.git ~/.minimax-skills
+
+mkdir -p ~/.config/opencode/skills
+for skill in ~/.minimax-skills/skills/*/; do
+    skill_name=$(basename "$skill")
+    ln -s "$skill" ~/.config/opencode/skills/minimax-"$skill_name"
+done
+```
+
+### Windows (PowerShell)
+
+```powershell
+git clone https://github.com/MiniMax-AI/skills.git "$env:USERPROFILE\.minimax-skills"
+
+New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.config\opencode\skills"
+Get-ChildItem "$env:USERPROFILE\.minimax-skills\skills" -Directory | ForEach-Object {
+    New-Item -ItemType SymbolicLink -Path "$env:USERPROFILE\.config\opencode\skills\minimax-$($_.Name)" -Target $_.FullName
+}
+```
+
+> **注意：** 在 Windows 上创建符号链接可能需要管理员权限或启用开发者模式。
+
+重启 OpenCode 以发现技能。
+
+验证方法：询问"列出可用技能"
+
+## 可用技能
+
+- **frontend-dev** — 前端开发，包含 UI 设计、动画、AI 生成媒体资源
+- **fullstack-dev** — 全栈后端架构和前后端集成
+- **android-native-dev** — Android 原生应用开发，采用 Material Design 3
+- **ios-application-dev** — iOS 应用开发，包含 UIKit、SnapKit 和 SwiftUI
+- **shader-dev** — GLSL 着色器技术，用于创建惊艳的视觉效果（兼容 ShaderToy）
+- **gif-sticker-maker** — 将照片转换为动画 GIF 贴纸（Funko Pop / Pop Mart 风格）
+- **minimax-pdf** — 使用基于令牌的设计系统生成、填写和重新格式化 PDF 文档
+- **pptx-generator** — 生成、编辑和读取 PowerPoint 演示文稿
+- **minimax-xlsx** — 打开、创建、读取、分析、编辑或验证 Excel/电子表格文件
+- **minimax-docx** — 使用 OpenXML SDK 专业创建、编辑和格式化 Word 文档
+
+## 更新
+
+```bash
+cd ~/.minimax-skills && git pull
+```
+
+符号链接将自动指向更新后的内容，无需重新链接。
+
+## 卸载
+
+### macOS / Linux
+
+```bash
+rm -f ~/.config/opencode/skills/minimax-*
+rm -rf ~/.minimax-skills
+```
+
+### Windows (PowerShell)
+
+```powershell
+Get-ChildItem "$env:USERPROFILE\.config\opencode\skills\minimax-*" | Remove-Item -Force
+Remove-Item -Recurse -Force "$env:USERPROFILE\.minimax-skills"
+```
+
+## 故障排除
+
+### 找不到技能
+
+1. 验证符号链接是否存在：`ls -la ~/.config/opencode/skills/`
+2. 每个技能文件夹应包含 `SKILL.md` 文件
+3. 安装后重启 OpenCode
+
+## 获取帮助
+
+- 问题反馈：https://github.com/MiniMax-AI/skills/issues

--- a/README_zh.md
+++ b/README_zh.md
@@ -63,7 +63,7 @@ mkdir -p ~/.config/opencode/skills
 ln -s ~/.minimax-skills/skills/* ~/.config/opencode/skills/
 ```
 
-重启 OpenCode 以发现技能。详见 [`.opencode/INSTALL.md`](.opencode/INSTALL.md)。
+重启 OpenCode 以发现技能。详见 [`.opencode/INSTALL_zh.md`](.opencode/INSTALL_zh.md)。
 
 ### VS Code
 


### PR DESCRIPTION
# 中文

## 总结
修复 OpenCode 安装脚本，使 MiniMax Skills 支持独立管理，避免与用户其他 Skills 冲突。
## 原有问题
原安装命令 `ln -s ~/.minimax-skills/skills/* ~/.config/opencode/skills/` 存在两个问题：
1. **无法识别** — 创建的符号链接无法区分哪些是 MiniMax 的 Skills，用户难以独立管理
2. **卸载风险** — 原卸载命令直接删除整个 `skills` 目录，会误删用户在该目录中安装的其他 Skills
## 解决方案
| 操作 | 原行为 | 修复后 |
|------|--------|--------|
| 安装 | `ln -s skills/* skills/` 创建单一错误链接 | 循环创建 `minimax-{skill_name}` 独立链接 |
| 卸载 | 删除整个 `skills` 目录 | 仅删除 `minimax-*` 前缀的符号链接 |
用户现在可以：
- 清晰识别哪些是 MiniMax 的 Skills
- 安全卸载，仅移除 MiniMax 相关链接，不影响其他 Skills
## 变更
- 修复符号链接创建逻辑（主要）
- 修复 Windows PowerShell 命名（次要）
- 新增中文版安装指南（低优先级）

---

# English

## Summary
Fix OpenCode installation script to enable independent MiniMax Skills management, avoiding conflicts with user's other Skills.
## Problem
The original install command `ln -s ~/.minimax-skills/skills/* ~/.config/opencode/skills/` has two issues:
1. **Unidentifiable** — Created symlinks make it impossible to distinguish which Skills belong to MiniMax
2. **Unsafe uninstall** — Original uninstall command deletes the entire `skills` directory, removing user's other Skills installed in the same location
## Solution
| Action | Before | After |
|--------|--------|-------|
| Install | `ln -s skills/* skills/` creates single broken link | Loop creates individual `minimax-{skill_name}` symlinks |
| Uninstall | Deletes entire `skills` directory | Removes only `minimax-*` prefixed symlinks |
Users can now:
- Clearly identify which Skills are MiniMax's
- Safely uninstall, removing only MiniMax links without affecting other Skills
## Changes
- Fix symlink creation logic (primary)
- Fix Windows PowerShell naming (secondary)
- Add Chinese installation guide (low priority)