### PR TITLE
docs(minimax-multimodal-toolkit): clarify sandbox env setup

### DIFF
--- a/skills/minimax-multimodal-toolkit/SKILL.md
+++ b/skills/minimax-multimodal-toolkit/SKILL.md
@@ -54,12 +54,15 @@ export MINIMAX_API_HOST="https://api.minimaxi.com"
 export MINIMAX_API_HOST="https://api.minimax.io"
 ```
 
+**Sandboxed agent note:** if you are using Claude Code, Codex, Cursor, or another sandboxed AI runtime, updating `~/.zshrc` / `~/.bashrc` alone may not affect an already-running app session. After changing your shell profile, restart the IDE/agent, or launch it from a terminal where `MINIMAX_API_HOST` is already exported. If the tool has its own environment-variable settings, configure the value there as well.
+
 **IMPORTANT — When API Host is missing:**
 Before running any script, check if `MINIMAX_API_HOST` is set in the environment. If it is NOT configured:
 1. Ask the user which service endpoint their MiniMax account uses:
    - **China Mainland** → `https://api.minimaxi.com`
    - **Global** → `https://api.minimax.io`
-2. Instruct and help user to set it via `export MINIMAX_API_HOST="https://api.minimaxi.com"` (or the global variant) in their terminal or add it to their shell profile (`~/.zshrc` / `~/.bashrc`) for persistence
+2. Instruct and help user to set it via `export MINIMAX_API_HOST="https://api.minimaxi.com"` (or the global variant) in the same terminal session, or add it to their shell profile (`~/.zshrc` / `~/.bashrc`) for persistence
+3. If they are using a sandboxed agent/IDE, tell them to restart the app after updating their profile, or configure the variable in the tool's own environment settings if available
 
 ### API Key Configuration
 
@@ -71,10 +74,13 @@ export MINIMAX_API_KEY="your-api-key-here"
 
 The key starts with `sk-api-` or `sk-cp-`, obtainable from https://platform.minimaxi.com (China) or https://platform.minimax.io (Global)
 
+**Sandboxed agent note:** if you save `MINIMAX_API_KEY` to `~/.zshrc` / `~/.bashrc`, an already-running AI tool may still not see it. Restart the IDE/agent after updating your shell profile, or start the tool from a terminal where the key is already exported. If the tool exposes its own environment-variable configuration, prefer that.
+
 **IMPORTANT — When API Key is missing:**
 Before running any script, check if `MINIMAX_API_KEY` is set in the environment. If it is NOT configured:
 1. Ask the user to provide their MiniMax API key
-2. Instruct and help user to set it via `export MINIMAX_API_KEY="sk-..."` in their terminal or add it to their shell profile (`~/.zshrc` / `~/.bashrc`) for persistence
+2. Instruct and help user to set it via `export MINIMAX_API_KEY="sk-..."` in the same terminal session, or add it to their shell profile (`~/.zshrc` / `~/.bashrc`) for persistence
+3. If they are using a sandboxed agent/IDE, tell them to restart the app after updating their profile, or configure the variable in the tool's own environment settings if available
 
 ## Plan Limits & Quotas
 

--- a/skills/minimax-multimodal-toolkit/scripts/check_environment.sh
+++ b/skills/minimax-multimodal-toolkit/scripts/check_environment.sh
@@ -70,6 +70,8 @@ check_api_host() {
     echo "[FAIL] MINIMAX_API_HOST not set"
     echo "  China Mainland: export MINIMAX_API_HOST='https://api.minimaxi.com'"
     echo "  Global:         export MINIMAX_API_HOST='https://api.minimax.io'"
+    echo "  If you stored it in ~/.zshrc or ~/.bashrc, restart your IDE/agent so the new value is inherited."
+    echo "  In sandboxed runtimes, you may need to configure the variable in the app's own environment settings."
     return 1
   fi
   if [[ "$api_host" != "https://api.minimaxi.com" && "$api_host" != "https://api.minimax.io" ]]; then
@@ -86,6 +88,8 @@ check_api_key() {
   if [[ -z "$api_key" ]]; then
     echo "[FAIL] MINIMAX_API_KEY not set"
     echo "  export MINIMAX_API_KEY='your-key'"
+    echo "  If you already added it to ~/.zshrc or ~/.bashrc, restart your IDE/agent or launch it from a shell where the variable is exported."
+    echo "  In sandboxed runtimes, set the variable in the tool's environment settings if available."
     return 1
   fi
   if [[ "$api_key" != sk-api* && "$api_key" != sk-cp* ]]; then


### PR DESCRIPTION
## What
- clarify in `minimax-multimodal-toolkit` that exporting `MINIMAX_API_KEY` or `MINIMAX_API_HOST` to `~/.zshrc` / `~/.bashrc` may not affect an already-running sandboxed agent session
- tell users to restart the IDE/agent after updating their shell profile, or configure the variables in the tool's own environment settings when available
- make `scripts/check_environment.sh` print sandbox-aware remediation instead of only suggesting `export ...`

## Why
Issue #41 reports a real usability gap: users can follow the current instructions, save `MINIMAX_API_KEY` to their shell profile, and still see the skill fail inside a sandboxed agent runtime because the running app never inherited the new environment.

This PR is scoped to one documentation/runtime-guidance improvement in `minimax-multimodal-toolkit`: make the missing-key path actionable for sandboxed AI tools.

Fixes #41
