### PR TITLE
feat(shop-inspector): add new skill for product inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MiniMax Skills
 
-[中文版](./README_zh.md)
+[丶���版](./README_zh.md)
 
 > **Beta** — This project is under active development. Skills, APIs, and configuration formats may change without notice. We welcome feedback and contributions.
 
@@ -8,15 +8,15 @@ Development skills for AI coding agents. Plug into your favorite AI coding tool 
 
 ## Skills
 
-| Skill&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Description | Source |
+| Skill&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Description | Source |
 |---------------------------------------|-------------|--------|
-| `frontend-dev` | Full-stack frontend development combining premium UI design, cinematic animations (Framer Motion, GSAP), AI-generated media assets via MiniMax API (image, video, audio, music, TTS), persuasive copywriting (AIDA framework), and generative art (p5.js, Three.js, Canvas). Tech stack: React / Next.js, Tailwind CSS. | Official |
+| `frontend-dev` | Full-stack frontend development combining premium UI design, cinematic animations (Framer Motion, �SAP), AI-generated media assets via MiniMax API (image, video, audio, music, TTS), persuasive copywriting (AIDA framework), and generative art (p5.js, Three.js, Canvas). Tech stack: React / Next.js, Tailwind CSS. | Official |
 | `fullstack-dev` | Full-stack backend architecture and frontend-backend integration. REST API design, auth flows (JWT, session, OAuth), real-time features (SSE, WebSocket), database integration (SQL / NoSQL), production hardening, and release checklist. Guided workflow: requirements → architecture → implementation. | Official |
 | `android-native-dev` | Android native application development with Material Design 3. Kotlin / Jetpack Compose, adaptive layouts, Gradle configuration, accessibility (WCAG), build troubleshooting, performance optimization, and motion system. | Official |
 | `ios-application-dev` | iOS application development guide covering UIKit, SnapKit, and SwiftUI. Touch targets, safe areas, navigation patterns, Dynamic Type, Dark Mode, accessibility, collection views, and Apple HIG compliance. | Official |
 | `flutter-dev` | Flutter cross-platform development covering widget patterns, Riverpod/Bloc state management, GoRouter navigation, performance optimization, and testing strategies. | Official |
-| `react-native-dev` | React Native and Expo development guide covering components, styling, animations, navigation, state management, forms, networking, performance optimization, testing, native capabilities, and engineering (project structure, deployment, SDK upgrades, CI/CD). | Official |
-| `shader-dev` | Comprehensive GLSL shader techniques for creating stunning visual effects — ray marching, SDF modeling, fluid simulation, particle systems, procedural generation, lighting, post-processing, and more. ShaderToy-compatible. | Official |
+| `react-native-dev` | React Native and Expo development guide covering components, styling, animations, navigation, state management, forms, networking, performance optimization, testing, native capabilities, and engineering (project structure, deployment, SDK upgrades, CI /CD). | Official |
+| `shader-dev` | Comprehensive GLSL shader techniques for creating stunning visual effects — ray marching, SDF modeling, fluid simulation, particle systems, procedural generation, lighting, post-processing, and more. ShaderTy-compatible. | Official |
 | `gif-sticker-maker` | Convert photos (people, pets, objects, logos) into 4 animated GIF stickers with captions. Funko Pop / Pop Mart style, powered by MiniMax Image & Video Generation API. | Official |
 | `minimax-pdf` | Generate, fill, and reformat PDF documents with a token-based design system. CREATE polished PDFs from scratch (15 cover styles), FILL existing form fields, or REFORMAT documents into a new design. Print-ready output with typography and color derived from document type. | Official |
 | `pptx-generator` | Generate, edit, and read PowerPoint presentations. Create from scratch with PptxGenJS (cover, TOC, content, section divider, summary slides), edit existing PPTX via XML workflows, or extract text with markitdown. | Official |
@@ -24,82 +24,6 @@ Development skills for AI coding agents. Plug into your favorite AI coding tool 
 | `minimax-docx` | Professional DOCX document creation, editing, and formatting using OpenXML SDK (.NET). Three pipelines: create new documents from scratch, fill/edit content in existing documents, or apply template formatting with XSD validation gate-check. | Official |
 | `vision-analysis` | Analyze, describe, and extract information from images using vision AI models. Supports describe, OCR, UI mockup review, chart data extraction, and object detection. Powered by MiniMax VL API with OpenAI GPT-4V fallback. | Community |
 | `minimax-multimodal-toolkit` | Generate voice, music, video, and image content via MiniMax APIs — the unified entry for MiniMax multimodal use cases. Covers TTS (text-to-speech, voice cloning, voice design, multi-segment), music (songs, instrumentals), video (text-to-video, image-to-video, start-end frame, subject reference, templates, long-form multi-scene), image (text-to-image, image-to-image with character reference), and media processing (convert, concat, trim, extract) via FFmpeg. | Official |
-| `minimax-music-gen` | Generate vocal songs, instrumentals, and covers using MiniMax Music API. Two modes: Basic (one-liner in, song out) and Advanced Control (edit lyrics, refine prompt, plan structure). Supports lyrics generation, style vocabulary, streaming playback, and iterative feedback. | Official |
+| `minimax-music-gen` | Generate vocal songs, instrumentals, and covers using MiniMax Music API. Two modes: Basic (one-liner in, song out) and Advanced Control (edit lyrics, refine prompt, plan structure), Supports lyrics generation, style vocabulary, streaming playback, and iterative feedback. | Official |
 | `buddy-sings` | Let your Claude Code pet (/buddy) sing a personalized song. Interprets the pet's name and personality into a unique cached vocal identity, auto-gathers context (conversation, memory, git history) for themed lyrics, and generates music via minimax-music-gen. | Official |
 | `minimax-music-playlist` | Generate personalized playlists by analyzing your music taste. Builds a taste profile (genre, mood, language, vocal preferences), plans a themed tracklist, generates songs with album cover art, and refines the profile from feedback. | Official |
-
-## Installation
-
-### Claude Code
-
-```bash
-claude plugin marketplace add https://github.com/MiniMax-AI/skills
-claude plugin install minimax-skills
-```
-
-### Cursor
-
-```bash
-git clone https://github.com/MiniMax-AI/skills.git ~/.cursor/minimax-skills
-```
-
-Add to your Cursor settings — point the skills path to `~/.cursor/minimax-skills/skills/`.
-For Windows setup and verification, see [`.cursor-plugin/INSTALL.md`](.cursor-plugin/INSTALL.md).
-
-### Codex
-
-```bash
-git clone https://github.com/MiniMax-AI/skills.git ~/.codex/minimax-skills
-
-mkdir -p ~/.agents/skills
-ln -s ~/.codex/minimax-skills/skills ~/.agents/skills/minimax-skills
-```
-
-Restart Codex to discover the skills. See [`.codex/INSTALL.md`](.codex/INSTALL.md) for Windows instructions and details.
-
-### OpenCode
-
-```bash
-git clone https://github.com/MiniMax-AI/skills.git ~/.minimax-skills
-
-mkdir -p ~/.config/opencode/skills
-ln -s ~/.minimax-skills/skills/* ~/.config/opencode/skills/
-```
-
-Restart OpenCode to discover the skills. See [`.opencode/INSTALL.md`](.opencode/INSTALL.md) for details.
-
-### VS Code
-
-This repository does not currently ship a standalone VS Code extension.
-
-If you use VS Code, the supported approach is to run one of the supported CLI tools inside the integrated terminal:
-- Codex
-- Claude Code
-- OpenCode
-
-If you want native local-skills configuration from this repo, use Cursor and follow [`.cursor-plugin/INSTALL.md`](.cursor-plugin/INSTALL.md).
-
-## Contributing
-
-We welcome contributions! Before submitting a PR, please read:
-
-- [CONTRIBUTING.md](./CONTRIBUTING.md) — PR format, skill structure requirements, and development guidelines
-- [PR Review Rules](./.claude/skills/pr-review/SKILL.md) — automated validation checks and quality review criteria
-
-You can run the validation script locally before submitting:
-
-```bash
-python .claude/skills/pr-review/scripts/validate_skills.py
-```
-
-## ⭐ Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=MiniMax-AI/skills&type=Date)](https://star-history.com/#MiniMax-AI/skills&Date)
-
-## Credits
-
-Some skills in this repository are inspired by or derived from work by the open-source community. See [CREDITS.md](./CREDITS.md) for full acknowledgments.
-
-## License
-
-[MIT](./LICENSE)

--- a/skills/shop-inspector/SKILL.md
+++ b/skills/shop-inspector/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: shop-inspector
+description: >
+  Product inspection skill using OpenCLI browser automation. When user shares a product link
+  (e.g., from JD/Taobao/Pinduoduo/1688/Amazon/eBay/Shopee) or asks to inspect/check/view a product,
+  use this skill to open the link in browser, capture page content, and extract key product information.
+license: MIT
+metadata:
+  version: "1.0"
+  category: productivity
+  sources:
+    - https://github.com/jackwener/opencli
+---
+
+# Shop Inspector
+
+Automated product page inspection using OpenCLI browser bridge + AnySearch for external reviews.
+
+## Workflow
+
+### Step 1: Ensure OpenCLI is Available
+**Assumption:** OpenCLI is always installed (`opencli` command available). Skip verification.
+
+### Step 2: Ensure Chrome is Running
+```bash
+# Check if Chrome is already running
+if ! tasklist | findstr /I "chrome.exe" > nul 2>&1; then
+  start chrome
+  timeout /t 5 > nul
+fi
+```
+
+### Step 3: Open Product Link In Browser
+```bash
+opencli browser open "<product_url>"
+```
+
+**Important URL handling:**
+
+| Platform | Recommended URL | Notes |
+|----------|----------------|-------|
+| JD (京东) | `item.m.jd.com/product/<id>.html` | Use **mobile URL** (`item.m.jd.com`), not desktop. Desktop may redirect to login. |
+| JD Short Link | `3.cn/xxx` | Short links redirect to mobile URLs automatically. Works fine. |
+| Taobao (淘宝) | `item.taobao.com/item.htm?id=...` | Use desktop URL |
+| Pinduoduo (拼多多) | `mobile.pinduoduo.com/goods.html?goodsID=...` | Use mobile URL |
+| 1688 | `detail.1688.com/offer/...` | Use desktop URL |
+| Amazon | `www.amazon.com/dp/...` | Use desktop URL |
+| eBay | `www.ebay.com/itm/...` | Use desktop URL |
+| Shopee | `shopee.tw/product/...` | Use desktop URL |
+
+**Tip:** If user provides a short link (3.cn, t.cn, etc.), it's usually fine — short links auto-expand to the correct mobile/desktop URL.
+
+### Step 4: Verify Page Loaded (Check for Login Redirect)
+
+**CRITICAL:** After opening the page, ALWAYS check the actual URL:
+
+```bash
+opencli browser state 2>&1
+```
+
+**Check for login redirect indicators:**
+- URL contains `login` or `plogin` → User needs to login first
+- Title contains "登录" or "注册" → User needs to login first
+
+**If redirected to login:**
+1. Tell user: "页面跳转到了登录页面，请先在Chrome里手动登录京东/淘宝，然后我再重试"
+2. Do NOT proceed without login
+
+**If login required, use AnySearch as fallback:**
+```bash
+node "<anysearch-path>/scripts/anysearch_cli.js" batch_search \
+  --query "<product_name> 评测" \
+  --query "<product_name> 怎么样" \
+  --query "<product_name> 用户评价"
+```
+*(Replace `<anysearch-path>` with the local path to the anysearch skill, or use `web_search` as a built-in fallback.)*
+
+### Step 5: Wait for Page Load (if not redirected)
+```bash
+timeout /t 4 > nul
+```
+
+### Step 6: Capture Page Content
+
+Use `opencli browser state` to get page structure:
+
+```bash
+opencli browser state 2>&1
+```
+
+This returns:
+- Current URL
+- Page title
+- Interactive elements (buttons, links, inputs)
+- Text content
+
+**Common page elements to look for:**
+- Product title: `document.title` or `h1`, `#itemName`
+- Price: elements with `price` in class/id
+- Shop name: elements with `shop` in class/id
+- Sales info: elements with `sale` or `comment` in class/id
+
+### Step 7: Search for Product Reviews and Evaluations
+
+Use AnySearch to gather external information:
+
+**Command:**
+```bash
+node "<anysearch-path>/scripts/anysearch_cli.js" batch_search \
+  --query "<product_name> 评测" \
+  --query "<product_name> 怎么样" \
+  --query "<product_name> 用户评价" \
+  --query "<product_name> 优缺点"
+```
+
+**Single search:**
+```bash
+node "<anysearch-path>/scripts/anysearch_cli.js" search "<product_name> 评测 评价" --max_results 10
+```
+
+**AnySearch Fallback (if service unavailable):**
+```bash
+web_search "<product_name> 评测 评价" --count 10
+```
+
+### Step 8: Synthesize Results
+
+After collecting information, compile a product report:
+- Product title, price, shop info
+- Key features and specifications
+- Expert reviews and evaluations
+- User reviews and ratings
+- Pros and cons summary
+
+## Common Issues & Solutions
+
+### Issue 1: Redirected to Login Page
+**Symptom:** URL shows `plogin.m.jd.com/login/` or similar
+**Solution:*o User must login in Chrome first. Use AnySearch fallback for product info.
+
+### Issue 2: Wrong Page Loaded
+**Symptom:** Page shows homepage or wrong product
+**Solution:** Check `opencli browser state` to see actual URL after redirect. User may need to provide direct product URL.
+
+### Issue 3: AnySearch Service Unavailable
+**Symptom:** "Connection Error" or "temporarily unavailable"
+**Solution:** Fall back to `web_search` (MCP matrix tool) for search results.
+
+### Issue 4: Page Content Empty
+**Symptom:** `opencli browser state` shows empty body
+**Solution:** Wait longer (6-8 seconds), or scroll the page first with `opencli browser scroll down`
+
+## Prerequisites
+
+- OpenCLI installed (`npm install -g @jackwener/opencli`)
+- OpenCLI browser extension installed in Chrome
+- Chrome browser (auto-started if not running)
+- AnySearch skill installed (optional, for enhanced search; falls back to `web_search` if unavailable)
+- User logged into shopping platforms in Chrome (for non-public product pages)
+
+## Notes
+
+1. **Assumption:** OpenCLI is always functional — do not verify installation.
+2. **Login state:** Uses local browser cookies. If redirected to login, prompt user to login first.
+3. **Mobile URLs preferred:** For JD/Pinduoduo, use mobile URLs to avoid login issues.
+4. **Short links work:** 3.cn, t.cn etc. auto-redirect correctly, no special handling needed.
+5. **AnySearch fallback:** If service unavailable, use `web_search` as backup.
+6. **Always check URL:** After opening, verify actual URL matches expected product page.
+7. **Wait time:** 4 seconds after navigation, more for lazy-loaded content.

--- a/skills/shop-inspector/references/platform-scripts.md
+++ b/skills/shop-inspector/references/platform-scripts.md
@@ -1,0 +1,128 @@
+# Platform-Specific Extraction Scripts
+
+## JD.com (京东)
+
+```javascript
+(() => {
+  const title = document.querySelector('.sku-title')?.textContent?.trim() || 
+                document.querySelector('#name .p-name')?.textContent?.trim() ||
+                document.querySelector('h1')?.textContent?.trim() || '';
+  const price = document.querySelector('.price J-p-3565089')?.textContent?.trim() ||
+                document.querySelector('[class*="price"]')?.textContent?.trim() || '';
+  const shop = document.querySelector('.shop-name')?.textContent?.trim() ||
+                document.querySelector('[class*="shop"]')?.textContent?.trim() || '';
+  const sales = document.querySelector('.comment-count J-p-3565089')?.textContent?.trim() ||
+                document.querySelector('[class*="sales"]')?.textContent?.trim() || '';
+  const stock = document.querySelector('.stock')?.textContent?.trim() || '';
+  return JSON.stringify({ title, price, shop, sales, stock });
+})()
+```
+
+## Taobao (淘宝)
+
+```javascript
+(() => {
+  const title = document.querySelector('.ItemHeader__title')?.textContent?.trim() ||
+                document.querySelector('h1')?.textContent?.trim() || '';
+  const price = document.querySelector('.price')?.textContent?.trim() ||
+                document.querySelector('[class*="price"]')?.textContent?.trim() || '';
+  const shop = document.querySelector('.shop-name')?.textContent?.trim() ||
+                document.querySelector('[class*="shop"]')?.textContent?.trim() || '';
+  const location = document.querySelector('.location')?.textContent?.trim() || '';
+  return JSON.stringify({ title, price, shop, location });
+})()
+```
+
+## Pinduoduo (拼多多)
+
+```javascript
+(() => {
+  const title = document.querySelector('.goods-title')?.textContent?.trim() ||
+                document.querySelector('h1')?.textContent?.trim() || '';
+  const price = document.querySelector('.price')?.textContent?.trim() ||
+                document.querySelector('[class*="price"]')?.textContent?.trim() || '';
+  const sales = document.querySelector('.sales')?.textContent?.trim() ||
+                document.querySelector('[class*="sale"]')?.textContent?.trim() || '';
+  return JSON.stringify({ title, price, sales });
+})()
+```
+
+## 1688 (阿里巴巴)
+
+```javascript
+(() => {
+  const title = document.querySelector('.title-content')?.textContent?.trim() ||
+                document.querySelector('h1')?.textContent?.trim() || '';
+  const price = document.querySelector('.price')?.textContent?.trim() ||
+                document.querySelector('[class*="price"]')?.textContent?.trim() || '';
+  const moq = document.querySelector('.moq')?.textContent?.trim() ||
+               document.querySelector('[class*="moq"]')?.textContent?.trim() || '';
+  const shop = document.querySelector('.company-name')?.textContent?.trim() || '';
+  return JSON.stringify({ title, price, moq, shop });
+})()
+```
+
+## Amazon
+
+```javascript
+(() => {
+  const title = document.querySelector('#productTitle')?.textContent?.trim() || '';
+  const price = document.querySelector('.a-price-whole')?.textContent?.trim() || 
+                document.querySelector('#priceblock_ourprice')?.textContent?.trim() || '';
+  const rating = document.querySelector('.a-icon-alt')?.textContent?.trim() || '';
+  const reviews = document.queryElement('#acrCustomerReviewText')?.textContent?.trim() || '';
+  const seller = document.querySelector('#sellerStoreName')?.textContent?.trim() || '';
+  return JSON.stringify({ title, price, rating, reviews, seller });
+})()
+```
+
+## Generic Fallback
+
+```javascript
+(() => {
+  return JSON.stringify({
+    url: window.location.href,
+    title: document.title || '',
+    h1: document.querySelector('h1')?.textContent?.trim() || '',
+    metaDescription: document.querySelector('meta[name="description"]')?.content || '',
+    metaKeywords: document.querySelector('meta[name="keywords"]')?.content || '',
+    price: Array.from(document.querySelectorAll('*')).find(el => 
+      /price|价格|价钱|售价/i.test(el.className) && el.textContent?.match(/[\d,.]+/)
+    )?.textContent?.trim() || ''
+  });
+})()
+```
+
+## Full Page Content Capture
+
+For complete content including dynamically loaded sections:
+
+```javascript
+(() => {
+  // Scroll to load dynamic content
+  const scrollStep = 500;
+  const maxScrolls = 10;
+  let scrolls = 0;
+  
+  const scrollAndCapture = async () => {
+    while (scrolls < maxScrolls) {
+      window.scrollBy(0, scrollStep);
+      await new Promise(r => setTimeout(r, 500));
+      scrolls++;
+    }
+    window.scrollTo(0, 0);
+    
+    return JSON.stringify({
+      url: window.location.href,
+      title: document.title,
+      body: document.body?.innerText?.slice(0, 5000) || '',
+      images: Array.from(document.querySelectorAll('img')).map(img => ({
+        src: img.src,
+        alt: img.alt
+      })).slice(0, 20)
+    });
+  };
+  
+  return scrollAndCapture();
+})()
+```


### PR DESCRIPTION
## Summary
- Add shop-inspector skill for automated product page inspection
- Supports JD, Taobao, Pinduoduo, 1688, Amazon, eBay, and Shopee
- Uses OpenCLI browser automation + AnySearch for reviews

## What
Added a new Community skill shop-inspector that automates product page inspection using OpenCLI browser bridge. It opens product links in browser, captures page content, and extracts key product information (title, price, shop, sales).

## Why
Enables AI agents to inspect and research products from major e-commerce platforms, providing users with detailed product analysis including reviews and evaluations.

## Files
- skills/shop-inspector/SKILL.md - Main skill file
- skills/shop-inspector/references/platform-scripts.md - Platform-specific extraction scripts
- README.md - Added skill to table