### PR TITLE
docs(minimax-multimodal-toolkit): upgrade default chat model to MiniMax-M3

### DIFF
--- a/skills/minimax-multimodal-toolkit/SKILL.md
+++ b/skills/minimax-multimodal-toolkit/SKILL.md
@@ -43,7 +43,7 @@ Always use these flags in non-interactive (agent/CI) contexts:
 
 ### text chat
 
-Chat completion. Default model: `MiniMax-M2.7`.
+Chat completion. Default model: `MiniMax-M3`.
 
 ```bash
 mmx text chat --message <text> [flags]
@@ -54,7 +54,7 @@ mmx text chat --message <text> [flags]
 | `--message <text>` | string, **required**, repeatable | Message text. Prefix with `role:` to set role (e.g. `"system:You are helpful"`, `"user:Hello"`) |
 | `--messages-file <path>` | string | JSON file with messages array. Use `-` for stdin |
 | `--system <text>` | string | System prompt |
-| `--model <model>` | string | Model ID (default: `MiniMax-M2.7`) |
+| `--model <model>` | string | Model ID (default: `MiniMax-M3`) |
 | `--max-tokens <n>` | number | Max tokens (default: 4096) |
 | `--temperature <n>` | number | Sampling temperature (0.0, 1.0] |
 | `--top-p <n>` | number | Nucleus sampling threshold |


### PR DESCRIPTION
## What

Update the documented default model for `mmx text chat` in `minimax-multimodal-toolkit/SKILL.md` from `MiniMax-M2.7` to `MiniMax-M3`.

## Why

`MiniMax-M3` is the current latest MiniMax text model — 512K context window, up to 128K output, and image input support — so the agent-facing skill documentation should default to it. Users can still select `MiniMax-M2.7` explicitly via `--model MiniMax-M2.7`.

## Diff summary

- `skills/minimax-multimodal-toolkit/SKILL.md` — change the two `Default model` references in the `text chat` section from `MiniMax-M2.7` to `MiniMax-M3` (2 line edit, 0 new files)

## Test plan

- `python3 .claude/skills/pr-review/scripts/validate_skills.py` produces no new errors (pre-existing `mmx-cli` name-mismatch warning is untouched).