### PR TITLE
fix: fix minimax-multimodal-toolkit wrong frontmatter name

### DIFF
--- a/skills/minimax-multimodal-toolkit/SKILL.md
+++ b/skills/minimax-multimodal-toolkit/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: mmx-cli
+name: minimax-multimodal-toolkit
 description: Use mmx to generate text, images, video, speech, and music via the MiniMax AI platform. Use when the user wants to create media content, chat with MiniMax models, perform web search, or manage MiniMax API resources from the terminal.
 ---
 


### PR DESCRIPTION
fix: fix frontmatter name in minimax-multimodal-toolkit SKILL.md

- Updated the name field in skills/minimax-multimodal-toolkit/SKILL.md

e0fdeef changed minimax-multimodal-toolkit frontmatter name to `mmx-cli` , but didn't change the skill directory name. This PR updates the frontmatter name to match the directory name: `minimax-multimodal-toolkit`
