### PR TITLE
fix(pr-review): flag legacy skill metadata

### DIFF
--- a/.claude/skills/pr-review/scripts/validate_skills.py
+++ b/.claude/skills/pr-review/scripts/validate_skills.py
@@ -22,12 +22,24 @@ import sys
 def extract_frontmatter(text):
     """Extract YAML frontmatter string between --- markers. Returns None if not found."""
     stripped = text.lstrip("\ufeff")
-    if not stripped.startswith("---"):
+    lines = stripped.splitlines()
+    if not lines or lines[0].strip() != "---":
         return None
-    end = stripped.find("---", 3)
-    if end == -1:
-        return None
-    return stripped[3:end]
+    for idx, line in enumerate(lines[1:], 1):
+        if line.strip() == "---":
+            return "\n".join(lines[1:idx])
+    return None
+
+
+def has_legacy_metadata_outside_frontmatter(text):
+    """Detect common legacy files with name/description lines outside YAML frontmatter."""
+    stripped = text.lstrip("\ufeff")
+    if stripped.startswith("---"):
+        return False
+    header = "\n".join(stripped.splitlines()[:12])
+    has_name = re.search(r"(?m)^name\s*:\s*\S+", header) is not None
+    has_description = re.search(r"(?m)^description\s*:\s*\S+", header) is not None
+    return has_name and has_description
 
 
 def parse_frontmatter_fields(fm_text):
@@ -126,7 +138,13 @@ def validate_skill(skill_dir):
 
     fm_text = extract_frontmatter(content)
     if fm_text is None:
-        errors.append("SKILL.md has no valid YAML frontmatter (missing --- markers)")
+        if has_legacy_metadata_outside_frontmatter(content):
+            errors.append(
+                "SKILL.md has name/description outside YAML frontmatter; "
+                "wrap required metadata between opening and closing --- markers"
+            )
+        else:
+            errors.append("SKILL.md has no valid YAML frontmatter (missing --- markers)")
         return errors, warnings
 
     fields = parse_frontmatter_fields(fm_text)


### PR DESCRIPTION
## What

Improves the PR review skill validator so malformed `SKILL.md` files with `name:` and `description:` outside YAML frontmatter get a specific actionable error instead of the generic missing-frontmatter message.

It also tightens frontmatter extraction so the opening and closing `---` markers must be standalone marker lines.

## Why

MiniMax/Mavis skill loaders depend on YAML frontmatter metadata. A common legacy shape looks like:

```md
# Skill: Example
name: example
description: Example trigger text.
```

That format is easy to miss during review, but downstream agents can index those skills with empty descriptions or stale metadata. This validator change catches the exact pattern and tells contributors how to fix it.

## Validation

- `python3 .claude/skills/pr-review/scripts/validate_skills.py --path <tmp legacy fixture>` fails with the new targeted message.
- `python3 .claude/skills/pr-review/scripts/validate_skills.py` still reports the existing baseline failure in `skills/minimax-multimodal-toolkit` (`name: mmx-cli` does not match the directory). I verified the same failure exists on `origin/main` before this patch.
