### PR TITLE
fix(minimax-docx): support .NET 8 project restore

### DIFF
--- a/skills/minimax-docx/scripts/env_check.sh
+++ b/skills/minimax-docx/scripts/env_check.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 DOTNET_DIR="$SCRIPT_DIR/dotnet"
+CLI_PROJECT="$DOTNET_DIR/MiniMaxAIDocx.Cli/MiniMaxAIDocx.Cli.csproj"
 
 # Force English output for dotnet CLI
 export DOTNET_CLI_UI_LANGUAGE=en
@@ -60,34 +61,41 @@ else
 fi
 
 # --- Critical: NuGet packages ---
-if [ -d "$DOTNET_DIR" ]; then
+if [ ! -d "$DOTNET_DIR" ]; then
+    printf "[FAIL]    %-14s directory not found: %s\n" "project" "$DOTNET_DIR"
+    STATUS="NOT READY"
+elif [ ! -f "$CLI_PROJECT" ]; then
+    printf "[FAIL]    %-14s file not found: %s\n" "project" "$CLI_PROJECT"
+    STATUS="NOT READY"
+else
     if [ -f "$DOTNET_DIR/MiniMaxAIDocx.Cli/bin/Debug/net10.0/MiniMaxAIDocx.Cli.dll" ] || \
        [ -f "$DOTNET_DIR/MiniMaxAIDocx.Cli/bin/Debug/net8.0/MiniMaxAIDocx.Cli.dll" ]; then
         printf "[OK]      %-14s built\n" "project"
     else
         # Try restore + build
-        if dotnet restore "$DOTNET_DIR" --verbosity quiet &>/dev/null; then
+        if restore_output=$(dotnet restore "$CLI_PROJECT" --verbosity quiet 2>&1); then
             printf "[OK]      %-14s packages restored\n" "nuget"
-            if dotnet build "$DOTNET_DIR" --verbosity quiet --no-restore &>/dev/null; then
+            if build_output=$(dotnet build "$CLI_PROJECT" --verbosity quiet --no-restore 2>&1); then
                 printf "[OK]      %-14s build succeeded\n" "project"
             else
-                printf "[FAIL]    %-14s build failed (run: dotnet build %s)\n" "project" "$DOTNET_DIR"
+                printf "[FAIL]    %-14s build failed\n" "project"
+                printf '%s\n' "$build_output" | sed 's/^/           /'
+                echo "  Retry: dotnet build \"$CLI_PROJECT\" --verbosity normal"
                 STATUS="NOT READY"
             fi
         else
             printf "[FAIL]    %-14s restore failed\n" "nuget"
+            printf '%s\n' "$restore_output" | sed 's/^/           /'
             echo ""
             echo "  Common causes:"
             echo "    - No internet access (NuGet needs to download packages)"
             echo "    - Corporate proxy blocking nuget.org"
             echo "    - SSL certificate issues (try: dotnet nuget list source)"
+            echo "  Retry: dotnet restore \"$CLI_PROJECT\" --verbosity detailed"
             echo ""
             STATUS="NOT READY"
         fi
     fi
-else
-    printf "[FAIL]    %-14s directory not found: %s\n" "project" "$DOTNET_DIR"
-    STATUS="NOT READY"
 fi
 
 # --- Optional: pandoc ---

--- a/skills/minimax-docx/scripts/setup.ps1
+++ b/skills/minimax-docx/scripts/setup.ps1
@@ -13,6 +13,7 @@ $ErrorActionPreference = "Stop"
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ProjectDir = Split-Path -Parent $ScriptDir
 $DotnetDir = Join-Path $ScriptDir "dotnet"
+$CliProject = Join-Path (Join-Path $DotnetDir "MiniMaxAIDocx.Cli") "MiniMaxAIDocx.Cli.csproj"
 $LogFile = Join-Path $ProjectDir ".setup.log"
 
 # --- Output Helpers ---
@@ -200,11 +201,13 @@ if (-not (Test-Path $DotnetDir)) {
     Fail "Dotnet project directory not found: $DotnetDir"
     exit 1
 }
-
-Push-Location $DotnetDir
+if (-not (Test-Path $CliProject)) {
+    Fail "CLI project not found: $CliProject"
+    exit 1
+}
 
 Info "Restoring NuGet packages..."
-$restoreResult = & dotnet restore --verbosity quiet 2>&1
+$restoreResult = & dotnet restore $CliProject --verbosity quiet 2>&1
 if ($LASTEXITCODE -ne 0) {
     Fail "NuGet restore failed:"
     $restoreResult | ForEach-Object { Fail "  $_" }
@@ -212,23 +215,19 @@ if ($LASTEXITCODE -ne 0) {
     Fail "  - No internet (NuGet needs to download packages)"
     Fail "  - Corporate proxy/firewall blocking nuget.org"
     Fail "  - Insufficient disk space"
-    Fail "Try: dotnet restore --verbosity detailed"
-    Pop-Location
+    Fail "Try: dotnet restore `"$CliProject`" --verbosity detailed"
     exit 1
 }
 Log "NuGet packages restored"
 
 Info "Building project..."
-$buildResult = & dotnet build --verbosity quiet --no-restore 2>&1
+$buildResult = & dotnet build $CliProject --verbosity quiet --no-restore 2>&1
 if ($LASTEXITCODE -ne 0) {
     Fail "Build failed:"
     $buildResult | ForEach-Object { Fail "  $_" }
-    Pop-Location
     exit 1
 }
 Log "Project built successfully"
-
-Pop-Location
 
 # --- Verification ---
 if (-not $SkipVerify) {
@@ -237,10 +236,8 @@ if (-not $SkipVerify) {
     $testOutput = Join-Path $env:TEMP "minimax-docx-setup-test-$PID.docx"
 
     Info "Creating a test document..."
-    Push-Location $DotnetDir
-    $testResult = & dotnet run --project MiniMaxAIDocx.Cli -- create --type report --output $testOutput --title "Setup Test" 2>&1
+    $testResult = & dotnet run --project $CliProject -- create --type report --output $testOutput --title "Setup Test" 2>&1
     $testExitCode = $LASTEXITCODE
-    Pop-Location
 
     if ($testExitCode -eq 0 -and (Test-Path $testOutput)) {
         Log "Test document created: $testOutput"
@@ -269,6 +266,6 @@ Write-Host "  pandoc:      $pandocInfo"
 Write-Host "  Project:     $DotnetDir"
 Write-Host ""
 Write-Host "  Usage:"
-Write-Host "    dotnet run --project $DotnetDir\MiniMaxAIDocx.Cli -- create --type report --output my_report.docx"
+Write-Host "    dotnet run --project `"$CliProject`" -- create --type report --output my_report.docx"
 Write-Host ""
 Write-Host "  Log file: $LogFile"

--- a/skills/minimax-docx/scripts/setup.sh
+++ b/skills/minimax-docx/scripts/setup.sh
@@ -10,6 +10,7 @@ export DOTNET_CLI_UI_LANGUAGE=en
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 DOTNET_DIR="$SCRIPT_DIR/dotnet"
+CLI_PROJECT="$DOTNET_DIR/MiniMaxAIDocx.Cli/MiniMaxAIDocx.Cli.csproj"
 LOG_FILE="$PROJECT_DIR/.setup.log"
 
 # --- Colors ---
@@ -265,31 +266,31 @@ build_project() {
         fail "Dotnet project directory not found: $DOTNET_DIR"
         return 1
     fi
-
-    cd "$DOTNET_DIR"
+    if [ ! -f "$CLI_PROJECT" ]; then
+        fail "CLI project not found: $CLI_PROJECT"
+        return 1
+    fi
 
     info "Restoring NuGet packages..."
-    if ! dotnet restore --verbosity quiet 2>>"$LOG_FILE"; then
+    if ! dotnet restore "$CLI_PROJECT" --verbosity quiet 2>>"$LOG_FILE"; then
         fail "NuGet restore failed. Check network and $LOG_FILE for details."
         fail "Common causes:"
         fail "  - No internet access (NuGet needs to download packages)"
         fail "  - Corporate proxy blocking nuget.org"
         fail "  - Disk space insufficient"
         echo ""
-        fail "Try manually: cd $DOTNET_DIR && dotnet restore --verbosity detailed"
+        fail "Try manually: dotnet restore \"$CLI_PROJECT\" --verbosity detailed"
         return 1
     fi
     log "NuGet packages restored"
 
     info "Building project..."
-    if ! dotnet build --verbosity quiet --no-restore 2>>"$LOG_FILE"; then
+    if ! dotnet build "$CLI_PROJECT" --verbosity quiet --no-restore 2>>"$LOG_FILE"; then
         fail "Build failed. Check $LOG_FILE for details."
-        fail "Try manually: cd $DOTNET_DIR && dotnet build --verbosity normal"
+        fail "Try manually: dotnet build \"$CLI_PROJECT\" --verbosity normal"
         return 1
     fi
     log "Project built successfully"
-
-    cd "$PROJECT_DIR"
 }
 
 # --- Shell Script Permissions ---
@@ -410,7 +411,7 @@ verify_installation() {
     local test_output="/tmp/minimax-docx-setup-test-$$.docx"
 
     info "Creating a test document..."
-    if cd "$DOTNET_DIR" && dotnet run --project MiniMaxAIDocx.Cli -- create \
+    if dotnet run --project "$CLI_PROJECT" -- create \
         --type report --output "$test_output" --title "Setup Test" 2>>"$LOG_FILE"; then
         log "Test document created: $test_output"
 
@@ -430,8 +431,6 @@ verify_installation() {
         fail "Test document creation failed. Check $LOG_FILE for details."
         return 1
     fi
-
-    cd "$PROJECT_DIR"
 }
 
 # --- Summary ---
@@ -446,8 +445,8 @@ print_summary() {
     echo "  Project:     $DOTNET_DIR"
     echo ""
     echo "  Usage:"
-    echo "    dotnet run --project $DOTNET_DIR/MiniMaxAIDocx.Cli -- create --type report --output my_report.docx"
-    echo "    bash $SCRIPT_DIR/env_check.sh     # Quick environment check"
+    echo "    dotnet run --project \"$CLI_PROJECT\" -- create --type report --output my_report.docx"
+    echo "    bash \"$SCRIPT_DIR/env_check.sh\"     # Quick environment check"
     echo ""
     echo "  Log file: $LOG_FILE"
 }


### PR DESCRIPTION
## What

- Restore and build `MiniMaxAIDocx.Cli.csproj` explicitly in the Bash and PowerShell setup paths.
- Make `env_check.sh` print the real restore/build error and an exact retry command instead of hiding all output.
- Use the explicit project path for the verification run and quote displayed paths.

## Why

On a clean checkout with .NET SDK 8.0.125 / MSBuild 17.8, restoring the `scripts/dotnet` directory selects `MiniMaxAIDocx.slnx` and fails with:

```text
MSB4068: The element <Solution> is unrecognized, or not supported in this context.
```

The existing environment check suppresses that error and reports a generic NuGet failure even when `nuget.org`, TLS, and the required packages are available. Restoring the CLI `.csproj` directly restores both referenced projects and works on the declared .NET 8 minimum.

Related to #24. This is intentionally a smaller alternative scoped only to the `.slnx` / .NET 8 compatibility bug and actionable diagnostics; it does not add offline-feed behavior.

## Verification

- `bash -n skills/minimax-docx/scripts/env_check.sh skills/minimax-docx/scripts/setup.sh`
- Clean `bash skills/minimax-docx/scripts/env_check.sh` on .NET SDK 8.0.125: `Status: READY`
- `bash skills/minimax-docx/scripts/setup.sh --minimal --skip-verify`
- `bash skills/minimax-docx/scripts/setup.sh --minimal`: builds successfully and creates the verification DOCX
- `python3 .claude/skills/pr-review/scripts/validate_skills.py --path skills/minimax-docx`: pass

The repository-wide validator still fails on the pre-existing `skills/minimax-multimodal-toolkit` name mismatch (`mmx-cli` vs. directory name); `minimax-docx` passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/skills/pr/109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787330062&installation_model_id=427615&pr_number=109&repository=MiniMax-AI%2Fskills&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fskills%2Fpull%2F109&signature=2ad872b6998f80cb06c67ce921a9b4f9cf5bd33285214c9831ae809fb775e9e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->