### PR TITLE
fix(minimax-xlsx): scripts crash printing ✓/→ through non-UTF8 Windows pipes

### DIFF
--- a/skills/minimax-xlsx/scripts/formula_check.py
+++ b/skills/minimax-xlsx/scripts/formula_check.py
@@ -33,6 +33,14 @@ import xml.etree.ElementTree as ET
 import re
 import json
 
+# Windows pipes default to a legacy codepage (e.g. cp1252) that cannot encode
+# the ✓/→ characters these tools print - degrade to "?" instead of crashing.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(errors="replace")
+    except (AttributeError, ValueError):
+        pass
+
 # OOXML SpreadsheetML namespace
 NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
 NSP = f"{{{NS}}}"

--- a/skills/minimax-xlsx/scripts/libreoffice_recalc.py
+++ b/skills/minimax-xlsx/scripts/libreoffice_recalc.py
@@ -28,6 +28,14 @@ import os
 import tempfile
 import argparse
 
+# Windows pipes default to a legacy codepage (e.g. cp1252) that cannot encode
+# the ✓/→ characters these tools print - degrade to "?" instead of crashing.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(errors="replace")
+    except (AttributeError, ValueError):
+        pass
+
 
 # ── LibreOffice discovery ───────────────────────────────────────────────────
 

--- a/skills/minimax-xlsx/scripts/shared_strings_builder.py
+++ b/skills/minimax-xlsx/scripts/shared_strings_builder.py
@@ -31,6 +31,14 @@ import sys
 import html
 import argparse
 
+# Windows pipes default to a legacy codepage (e.g. cp1252) that cannot encode
+# the ✓/→ characters these tools print - degrade to "?" instead of crashing.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(errors="replace")
+    except (AttributeError, ValueError):
+        pass
+
 
 HEADER = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
 SST_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"

--- a/skills/minimax-xlsx/scripts/style_audit.py
+++ b/skills/minimax-xlsx/scripts/style_audit.py
@@ -31,6 +31,14 @@ import re
 import tempfile
 import shutil
 
+# Windows pipes default to a legacy codepage (e.g. cp1252) that cannot encode
+# the ✓/→ characters these tools print - degrade to "?" instead of crashing.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(errors="replace")
+    except (AttributeError, ValueError):
+        pass
+
 NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
 NSP = f"{{{NS}}}"
 

--- a/skills/minimax-xlsx/scripts/xlsx_add_column.py
+++ b/skills/minimax-xlsx/scripts/xlsx_add_column.py
@@ -32,6 +32,14 @@ import sys
 import xml.dom.minidom
 import xml.etree.ElementTree as ET
 
+# Windows pipes default to a legacy codepage (e.g. cp1252) that cannot encode
+# the ✓/→ characters these tools print - degrade to "?" instead of crashing.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(errors="replace")
+    except (AttributeError, ValueError):
+        pass
+
 NS_SS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
 NS_REL = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
 

--- a/skills/minimax-xlsx/scripts/xlsx_insert_row.py
+++ b/skills/minimax-xlsx/scripts/xlsx_insert_row.py
@@ -34,6 +34,14 @@ import sys
 import xml.dom.minidom
 import xml.etree.ElementTree as ET
 
+# Windows pipes default to a legacy codepage (e.g. cp1252) that cannot encode
+# the ✓/→ characters these tools print - degrade to "?" instead of crashing.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(errors="replace")
+    except (AttributeError, ValueError):
+        pass
+
 NS_SS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
 NS_REL = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
 

--- a/skills/minimax-xlsx/scripts/xlsx_pack.py
+++ b/skills/minimax-xlsx/scripts/xlsx_pack.py
@@ -18,6 +18,14 @@ import os
 import zipfile
 import xml.etree.ElementTree as ET
 
+# Windows pipes default to a legacy codepage (e.g. cp1252) that cannot encode
+# the ✓/→ characters these tools print - degrade to "?" instead of crashing.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(errors="replace")
+    except (AttributeError, ValueError):
+        pass
+
 
 def validate_xml_files(source_dir: str) -> list[str]:
     """Return list of XML files that fail to parse."""

--- a/skills/minimax-xlsx/scripts/xlsx_reader.py
+++ b/skills/minimax-xlsx/scripts/xlsx_reader.py
@@ -22,6 +22,14 @@ import json
 import argparse
 from pathlib import Path
 
+# Windows pipes default to a legacy codepage (e.g. cp1252) that cannot encode
+# the ✓/→ characters these tools print - degrade to "?" instead of crashing.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(errors="replace")
+    except (AttributeError, ValueError):
+        pass
+
 
 # ---------------------------------------------------------------------------
 # Format detection and loading

--- a/skills/minimax-xlsx/scripts/xlsx_shift_rows.py
+++ b/skills/minimax-xlsx/scripts/xlsx_shift_rows.py
@@ -39,6 +39,14 @@ import re
 import xml.etree.ElementTree as ET
 import xml.dom.minidom
 
+# Windows pipes default to a legacy codepage (e.g. cp1252) that cannot encode
+# the ✓/→ characters these tools print - degrade to "?" instead of crashing.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(errors="replace")
+    except (AttributeError, ValueError):
+        pass
+
 
 def col_letter(n: int) -> str:
     """Convert 1-based column number to Excel column letter(s)."""

--- a/skills/minimax-xlsx/scripts/xlsx_unpack.py
+++ b/skills/minimax-xlsx/scripts/xlsx_unpack.py
@@ -18,6 +18,14 @@ import os
 import shutil
 import xml.dom.minidom
 
+# Windows pipes default to a legacy codepage (e.g. cp1252) that cannot encode
+# the ✓/→ characters these tools print - degrade to "?" instead of crashing.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(errors="replace")
+    except (AttributeError, ValueError):
+        pass
+
 
 def pretty_print_xml(content: bytes) -> str:
     """Pretty-print XML bytes. Returns original content on parse failure."""


### PR DESCRIPTION
Fixes #110.

## Problem
Every script in `skills/minimax-xlsx/scripts/` prints non-ASCII characters (`✓`, `→`, `—`, `─`). On Windows, Python encodes **piped** stdout with the legacy ANSI codepage (e.g. cp1252), which cannot represent them — the first such `print` raises `UnicodeEncodeError` and kills the script mid-operation, even though the underlying work (packing, validation, …) succeeded. Piped output is the common case: agent shells capture script output through pipes, as do installers and CI.

Observed in the wild on Windows 10 / Python 3.14 during an offline install verification (full traceback in #110); reproducible on any OS with:

```bash
PYTHONIOENCODING=cp1252 python3 skills/minimax-xlsx/scripts/xlsx_pack.py \
  skills/minimax-xlsx/templates/minimal_xlsx /tmp/test.xlsx | cat
```

## Fix
Add a small startup snippet to each of the ten scripts, right after the import block:

```python
for _stream in (sys.stdout, sys.stderr):
    try:
        _stream.reconfigure(errors="replace")
    except (AttributeError, ValueError):
        pass
```

Unencodable characters degrade to `?` instead of crashing. On UTF-8 terminals (all of Linux/macOS, and Windows consoles) output is byte-identical to before; exit codes and file outputs are untouched everywhere. The `try/except` keeps the scripts safe under detached/wrapped streams.

Verified: the repro above crashes before this change and completes with exit 0 after (the `✓` renders as `?` under cp1252, verbatim under UTF-8). All ten scripts still compile (`python -m py_compile`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/skills/pr/111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788440815&installation_model_id=427615&pr_number=111&repository=MiniMax-AI%2Fskills&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fskills%2Fpull%2F111&signature=5cb6fafcd1b556b130356e31d83c32c66a4e402a28aec7e88585192d4d524a6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->